### PR TITLE
Add arbitrary UserData field to File.cs

### DIFF
--- a/Assets/com.elringus.unitygoogledrive/Runtime/API/Data/File.cs
+++ b/Assets/com.elringus.unitygoogledrive/Runtime/API/Data/File.cs
@@ -510,5 +510,10 @@ namespace UnityGoogleDrive.Data
         /// Entries with null values are cleared in update and copy requests.
         /// </summary>
         public Dictionary<string, string> AppProperties { get; private set; }
+        /// <summary>
+        /// This property can be used to store whatever arbitrary data you want on this file.
+        /// </summary>
+        [Newtonsoft.Json.JsonIgnore]
+        public object UserData { get; set; }
     }
 }


### PR DESCRIPTION
Adds a custom field to the UnityGoogleDrive.Data.File script to avoid having to create wrapper classes for additional fields. 

This follows the same design pattern used in the popular InControl package for Unity:
http://www.gallantgames.com/incontrol-api/html/class_in_control_1_1_player_action.html#aeeccb94edafa8ab78eb999c2b2f97572